### PR TITLE
Revert "Rebasing (Glorot)"

### DIFF
--- a/DL_utils/Glorot_initialisation_state_dict.py
+++ b/DL_utils/Glorot_initialisation_state_dict.py
@@ -17,8 +17,9 @@ def init_weights(m):
     """
     Function from: https://stackoverflow.com/questions/49433936/how-do-i-initialize-weights-in-pytorch
     """
-    torch.nn.init.xavier_uniform_(m.weight)
-    m.bias.data.fill_(0.01)
+    if isinstance(m, nn.Linear):
+        torch.nn.init.xavier_uniform_(m.weight)
+        m.bias.data.fill_(0.01)
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()


### PR DESCRIPTION
Revert pull request "Rebasing (Glorot)". This pull request was created after performing a rebase on a forked repository (the one of Sdniss), where the intention was to insert a commit in between commit 3ecd0d1 and 183db74. This was to fix the Glorot initialisation which was only applied to linear layers initially (2bd1f04). As the rebase was pushed to the forked repository (Sdniss) with the --force flag after rebasing locally, all commits after the Glorot fix commit (183db74 up to fa97a4d) received a new commit number, i.e. 78c320a up to 5b2779a. Hence, these are duplicates. I would like to now go back to the state of the repository at commit 3ecd0d1, to then include the Glorot fix and any other code changes for our T1 transfer / federated experiments.